### PR TITLE
Update enshrouded server container for 2025-11 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN set -x \
     wget \
     software-properties-common \
     locales \
+    tini \
 && locale-gen en_US.UTF-8 \
 && update-locale LANG=en_US.UTF-8
 
@@ -106,4 +107,4 @@ EXPOSE 15637
 # --------------------------
 # Default Entrypoint
 # --------------------------
-ENTRYPOINT [ "/home/steam/entrypoint.sh" ]
+ENTRYPOINT [ "/usr/bin/tini", "--", "/home/steam/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,10 +100,11 @@ else
 fi
 
 # Update or install the Enshrouded dedicated server using SteamCMD
-su steam -c "./steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir /home/steam/enshrouded +login anonymous +app_update 2278520 +quit"
+./steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir /home/steam/enshrouded +login anonymous +app_update 2278520 +quit
 echo "Server files updated."
 
 # Launch the Enshrouded server executable using Wine
-su steam -c "wine /home/steam/enshrouded/enshrouded_server.exe"
-echo "Server launched successfully."
-/bin/bash
+# Using exec to replace the shell with wine, making it tini's direct child.
+# This allows tini to forward signals (SIGTERM, SIGINT, etc.) directly to wine
+echo "Launching Enshrouded server..."
+exec wine /home/steam/enshrouded/enshrouded_server.exe


### PR DESCRIPTION
I had a previous game install on a mapped container volume, which I had to issue some commands on in order to get working with the 2025-11 enshrouded update. It was like:

```
chown -R steam:steam /home/steam/enshrouded
rm /home/steam/enshrouded/steamapps/appmanifest_2278520.acf
su steam -c "./steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir /home/steam/enshrouded +login anonymous +app_update 2278520 validate +quit"
```

This patch also adds some signal forwarding so that the server process can exit sooner when the container is asked to stop.