### PR TITLE
Make enshrouded UID & GID variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ docker run -d \
 > - `bonsaibauer/enshrouded_server_docker:latest` is the **official prebuilt image** available on Docker Hub  
 > - You **don’t need to build the image yourself**, just pull and run it  
 > - The rest of the parameters are the same as in Option B and C
+> - `ENSHROUDED_USER_ID="$(id -u enshrouded)"` needed to set the correct User ID for enshrouded inside the container
+> - `ENSHROUDED_GROUP_ID="$(id -g enshrouded)"` needed to set the correct Group ID for enshrouded inside the container
 >
 > ✅ **Tip:** Configuration (`enshrouded_server.json`) is done in the mounted directory `/home/enshrouded/enshrouded_server_docker` as usual.
 
@@ -248,6 +250,8 @@ docker run -d \
 > - `--restart=always`: Automatically restarts the container if it stops or the host reboots.
 > - `-p 15637:15637/udp`: Maps the UDP port 15637 from the container to the host, required for the game server.
 > - `-v /home/enshrouded/enshrouded_server_docker:/home/steam/enshrouded`: Mounts a local directory for persistent data and configuration.
+> - `ENSHROUDED_USER_ID="$(id -u enshrouded)"` needed to set the correct User ID for enshrouded inside the container
+> - `ENSHROUDED_GROUP_ID="$(id -g enshrouded)"` needed to set the correct Group ID for enshrouded inside the container
 > - `-e ENSHROUDED_SERVER_NAME="myservername"`: Sets the server's visible name.
 > - `-e ENSHROUDED_SERVER_MAXPLAYERS=16`: Limits the number of players to 16.
 > - `-e ENSHROUDED_VOICE_CHAT_MODE="Proximity"`: Enables proximity-based voice chat.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ sudo mkdir -p /home/enshrouded
 sudo mkdir -p /home/enshrouded/enshrouded_server_docker
 
 # Set proper ownership 
-sudo chown 1001:1001 /home/enshrouded/enshrouded_server_docker
+sudo chown enshrouded:enshrouded /home/enshrouded/enshrouded_server_docker
 ```
 
 > 🛡️ This ensures that the container can write to `/home/enshrouded` and all server data stays in one clean location.
@@ -182,6 +182,8 @@ docker run -d \
   --name enshroudedserver \
   --restart=always \
   -p 15637:15637/udp \
+  -e ENSHROUDED_USER_ID="$(id -u enshrouded)" \
+  -e ENSHROUDED_USER_ID="$(id -g enshrouded)" \  
   -v /home/enshrouded/enshrouded_server_docker:/home/steam/enshrouded \
   bonsaibauer/enshrouded_server_docker:latest
 ```
@@ -226,6 +228,8 @@ docker run -d \
   --restart=always \
   -p 15637:15637/udp \
   -v /home/enshrouded/enshrouded_server_docker:/home/steam/enshrouded \
+  -e ENSHROUDED_USER_ID="$(id -u enshrouded)" \
+  -e ENSHROUDED_USER_ID="$(id -g enshrouded)" \  
   -e ENSHROUDED_SERVER_NAME="myservername" \
   -e ENSHROUDED_SERVER_MAXPLAYERS=16 \
   -e ENSHROUDED_VOICE_CHAT_MODE="Proximity" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,14 @@
 # Ensure .steam directory exists to avoid symlink issues
 mkdir -p /home/steam/.steam
 
-# If this is the first initialization of the container, create the server config
+# If this is the first initialization of the container, create the server config and change UID & GID to host IDs
 if [ ! -e /home/steam/enshrouded/enshrouded_server.json ]; then
 
     echo " ----- Starting initial configuration -----"
+
+    echo "Changing UID and GID to host IDs"
+    usermod -u "$ENSHROUDED_USER_ID" steam
+    groupmod -g "$ENSHROUDED_GROUP_ID" steam
 
     # Create server properties file using environment variables
     echo "Creating server configuration file..."


### PR DESCRIPTION
This hopefully fixes https://github.com/bonsaibauer/enshrouded_server_docker/issues/4.

- Added `ENSHROUDED_USER_ID` and `ENSHROUDED_GROUP_ID` to docker run commands
- Added corresponding documentation
- added `usermod` and `groupmod` to `entrypoint.sh` to change UID and GID for steam user to the host enshrouded user

The suggested changes from https://github.com/bonsaibauer/enshrouded_server_docker/issues/4#issuecomment-3814120677 won't work, since they run when the container is build and not, when it's deployed on a server.